### PR TITLE
[WIP] チャット画面　レイアウト作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
+gem 'font-awesome-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.12.2)
+    font-awesome-sass (5.12.0)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -138,6 +140,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.3.0)
+      ffi (~> 1.9)
     sexp_processor (4.14.1)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -176,6 +180,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -1,0 +1,126 @@
+/*!
+ * YUI 3.5.0 - reset.css (http://developer.yahoo.com/yui/3/cssreset/)
+ * http://cssreset.com
+ * Copyright 2012 Yahoo! Inc. All rights reserved.
+ * http://yuilibrary.com/license/
+ */
+/*
+    TODO will need to remove settings on HTML since we can't namespace it.
+    TODO with the prefix, should I group by selector or property for weight savings?
+*/
+html{
+  color:#000;
+  background:#FFF;
+}
+/*
+  TODO remove settings on BODY since we can't namespace it.
+*/
+/*
+  TODO test putting a class on HEAD.
+      - Fails on FF.
+*/
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+textarea,
+p,
+blockquote,
+th,
+td {
+  margin:0;
+  padding:0;
+}
+table {
+  border-collapse:collapse;
+  border-spacing:0;
+}
+fieldset,
+img {
+  border:0;
+}
+/*
+  TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
+*/
+address,
+caption,
+cite,
+code,
+dfn,
+em,
+strong,
+th,
+var {
+  font-style:normal;
+  font-weight:normal;
+}
+
+ol,
+ul {
+  list-style:none;
+}
+
+caption,
+th {
+  text-align:left;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size:100%;
+  font-weight:normal;
+}
+q:before,
+q:after {
+  content:'';
+}
+abbr,
+acronym {
+  border:0;
+  font-variant:normal;
+}
+/* to preserve line-height and selector appearance */
+sup {
+  vertical-align:text-top;
+}
+sub {
+  vertical-align:text-bottom;
+}
+input,
+textarea,
+select {
+  font-family:inherit;
+  font-size:inherit;
+  font-weight:inherit;
+}
+/*to enable resizing for IE*/
+input,
+textarea,
+select {
+  *font-size:100%;
+}
+/*because legend doesn't inherit in IE */
+legend {
+  color:#000;
+}
+/* YUI CSS Detection Stamp */
+#yui3-css-stamp.cssreset { display: none; }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,4 @@
+@import "reset";
+@import "modules/messages";
+@import "font-awesome-sprockets";
+@import "font-awesome";

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -1,0 +1,183 @@
+* {
+  box-sizing: border-box;
+}
+  .chat-space{
+    height: 100vh;
+    width: 100vw;
+    display: flex;
+    .chat-main{
+      height: 100vh;
+      width: calc(100vw - 300px);
+      background-color:#ffffff;
+      &__group-info{
+        height: 100px;
+        width: 100%;
+        background-color:#ffffff;
+        display: flex;
+        padding: 35px 40px ;
+        align-items: center;
+        justify-content: space-between;
+        &--title{
+          color: #333333;
+          font-size: 20px;
+          margin-top: auto;
+          &-list{
+            font-size: 12px;
+            color: #999999;
+            display: flex;
+            padding-top: 15px;
+          }
+          &-list--name{
+            font-size: 12px;
+            color: #999999;
+            margin-left: 5px;
+          }
+        }  
+        &--edit{
+          border: 1px solid #38aef0;
+          text-decoration: none;
+          width: 72px;
+          height: 40px;
+          &--btn{
+            color: #38aef0;
+            border: none;
+            font-size: 16px;
+            line-height: 40px;
+            margin-left: 20px;
+          }
+        }   
+      }   
+      
+      &__massage-list{
+        height: calc(100vh - 100px - 90px);
+        width: 100%;
+        background-color: #fafafa;
+        padding-left: 40px;
+        &--name{
+          padding-top: 35px;
+          padding-bottom: 12px;
+          font-size: 16px;
+          font-weight: bold;
+          color: #333333;
+          display: flex;
+          &--deta{
+            color: #999999;
+            font-size: 12px;
+            font-weight: normal;
+            padding-left: 10px;
+          }
+        }
+        &--coment{
+          color: #434a54;
+          font-size: 14px;
+          padding-bottom: 46px;
+
+        }
+
+      }
+      &__massage-from{
+        height: 90px;
+        width: 100%;
+        padding: 20px 40px;
+        background-color: #d2d2d2; 
+        display: flex;
+        &--coment{
+          height: 50px;
+          width: calc(100% - 115px);
+          display: flex;
+          background-color: #ffffff;
+          &-text{
+            height: 50px;
+            width: 100%;
+            border: none;
+            padding-left: 10px;
+            padding-right: 10px;
+          }    
+          &-image{
+            display: block;
+            line-height: 50px;
+            padding: 0 10px;
+            font-size: 25px;
+            &-btn{
+              display: none;
+            }
+          }
+        }
+        &--submit{
+          height: 50px;
+          width: 100px;
+          color: #ffffff;
+          background-color: #38aef0;
+          margin-left: 15px;
+        }
+       
+      }
+    }
+  
+    .side-ber{
+      height: 100vh;
+      width: 300px;
+      background-color: #253141;
+      &__user-name{
+        height: 100px;
+        width: 300px;
+        background-color: #253141;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        
+        .top-items{
+          height: 20px;
+          width: 260px;
+          display: flex;
+          justify-content: space-between;
+
+            &__name{
+            color: #ffffff;
+            font-size: 16px;
+            font-weight: bold;
+            }
+            &__icon{
+            width: 60px;
+            text-decoration: none;
+            color: #ffffff;
+            display: flex;
+            justify-content: flex-end;
+              &--btn{
+                display: block;
+                width: 18px;
+                margin-left: 5px;
+                
+              }
+            } 
+          }
+        }
+      
+      &__group-list{
+        height: calc(100vh - 100px);
+        width: 300px;
+        background-color: #2f3e51;
+        
+        &--chart{
+          width: 260px;
+          margin-left: 20px;
+           &--title{
+             font-size: 15px;
+             color: #ffffff;
+             padding-top: 20px;
+             padding-bottom: 5px;
+           }
+           &--comment{
+             font-size: 11px;
+             color: #ffffff;
+             padding-bottom: 40px;
+           }
+           
+          
+        }
+      }
+    }
+  }
+
+ 
+

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,0 +1,39 @@
+.chat-main
+  .chat-main__group-info
+    .chat-main__group-info--title
+      text
+      %ul.chat-main__group-info--title-list
+        Member :
+        %li<
+          .chat-main__group-info--title-list--name
+            fukuyama
+    .chat-main__group-info--edit
+      = link_to "#", class:"chat-main__group-info--edit chat-main__group-info--edit--btn" do
+        Edit
+
+  .chat-main__massage-list
+    .chat-main__massage-list--name
+      fukuyama
+      .chat-main__massage-list--name--deta
+        2020/05/22(fri) 21:42:00
+    .chat-main__massage-list--coment
+      こんばんは
+    .chat-main__massage-list--name
+      fukuyama
+      .chat-main__massage-list--name--deta
+        2020/05/22(fri) 21:42:00
+    .chat-main__massage-list--coment
+      おはようございます
+    
+  .chat-main__massage-from    
+    .chat-main__massage-from--coment
+      %input.chat-main__massage-from--coment-text{:type => "text", :placeholder => "type a message"}      
+      %label{class: "chat-main__massage-from--coment-image"}
+        = icon('far','image',)
+        %input{class: "chat-main__massage-from--coment-image-btn",type: "file"}
+    %input.chat-main__massage-from--submit{:type => "submit",:value => "Send"}
+      
+
+  
+    
+    

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -1,0 +1,23 @@
+.side-ber
+  .side-ber__user-name
+    .top-items
+      .top-items__name
+        akito
+      .top-items__icon
+        = link_to "#", class: "top-items__icon top-items__icon--btn" do
+          %i.far.fa-edit
+        = link_to "#", class: "top-items__icon top-items__icon--btn" do
+          %i.fa.fa-cog
+      
+  .side-ber__group-list
+    .side-ber__group-list--chart
+      .side-ber__group-list--chart--title
+        text
+      .side-ber__group-list--chart--comment
+        text
+    .side-ber__group-list--chart
+      .side-ber__group-list--chart--title
+        text
+      .side-ber__group-list--chart--comment
+        text
+  

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,2 +1,4 @@
-%h1 Messages#index
-%p Find me in app/views/messages/index.html.haml
+
+.chat-space
+  = render partial: "side_bar"
+  = render partial: "main_chat"


### PR DESCRIPTION
# what
サイドバー：登録者名、グループ作成アイコン、プロフィール編集アイコン作成
　　　　　　サイドバーグループ名、コメントの表示
メイン画面：グループ名、メンバー、編集画面のアイコンの作成
　　　　　　メッセージ投稿者名、日付、メッセージの表示
　　　　　　メッセージ入力フォーム、画像添付のアイコン、入力ボタンの作成
# why
サイドバー：誰がログインしているのかの表示とグループを作成するため
　　　　　　プロフィールの編集
　　　　　　どのグループに属しているのかの表示
メイン画面：グループのチャット画面を表示し、誰が入室しているのかの確認
　　　　　　[グループ名の編集とチャットメンバーの追加]
　　　　　　メッセージを投稿できるようにする

実装画面[https://gyazo.com/f4432dff4483db9a614c3befe4677fe8](url)